### PR TITLE
Support for Swift Concurrency

### DIFF
--- a/Sources/FeedKit/Parser/FeedParser.swift
+++ b/Sources/FeedKit/Parser/FeedParser.swift
@@ -121,6 +121,22 @@ public class FeedParser {
             result(self.parse())
         }
     }
+    /// Starts parsing the feed asynchronously. Parsing runs by default on the
+    /// global queue.
+    /// - Parameters:
+    ///   - queue: The queue on which the completion handler is dispatched.
+    /// - Returns: The parsed `Result`
+    @available(swift 5.5)
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    public func parseAsync(
+        queue: DispatchQueue = DispatchQueue.global()
+    ) async throws -> Feed {
+        try await withCheckedThrowingContinuation { continuation in
+            parseAsync(queue: queue) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
     
     /// Stops parsing XML feeds.
     public func abortParsing() {


### PR DESCRIPTION
adds an async wrapper around FeedParser.parseAsync(queue:result:) using a withCheckedThrowingContinuation so that it can be called in an asynchronous context using Swift Concurrency (async/await)